### PR TITLE
this endpoint doesn't have pagination

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -70,10 +70,12 @@ func (c *Client) GetUsers(ctx context.Context, options PageOptions) ([]User, str
 		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
 	}
 
-	usersURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getUsers, c.accountId), options)
+	usersURL, err := url.Parse(fmt.Sprintf(getUsers, c.accountId))
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, fmt.Errorf("invalid endpoint: %w", err)
 	}
+
+	usersURL = baseURL.ResolveReference(usersURL)
 
 	_, annos, err := c.doRequest(ctx, http.MethodGet, usersURL, &usersResponse)
 	if err != nil {


### PR DESCRIPTION
This endpoint is 400'ing in prod (but not in demo accounts)

https://www.docusign.net/restapi/v2.1/accounts/207050667/permission_profiles?count=50&start_position=0

I see it uses `count` which is not documented for this permission profiles:

https://developers.docusign.com/docs/esign-rest-api/reference/accounts/accountpermissionprofiles/list/?explorer=true

it is documented for users lists

https://developers.docusign.com/docs/esign-rest-api/reference/users/users/list/

I also see that the postman collection does not have a "counts" for this endpoint.

This could be the cause for the 400.