### PR TITLE
this endpoint doesn't have pagination

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -251,10 +251,12 @@ func (c *Client) GetPermissionProfiles(ctx context.Context, options PageOptions)
 		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
 	}
 
-	permissionProfilesURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getPermissionProfiles, c.accountId), options)
+	permissionProfilesURL, err := url.Parse(fmt.Sprintf(getPermissionProfiles, c.accountId))
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", nil, fmt.Errorf("invalid endpoint: %w", err)
 	}
+
+	permissionProfilesURL = baseURL.ResolveReference(permissionProfilesURL)
 
 	_, annos, err := c.doRequest(ctx, http.MethodGet, permissionProfilesURL, &permissionProfilesResponse)
 	if err != nil {


### PR DESCRIPTION
This endpoint is 400'ing in prod (but not in demo accounts)

https://www.docusign.net/restapi/v2.1/accounts/207050667/permission_profiles?count=50&start_position=0

I see it uses `count` which is not documented for this permission profiles:

https://developers.docusign.com/docs/esign-rest-api/reference/accounts/accountpermissionprofiles/list/?explorer=true

it is documented for users lists

https://developers.docusign.com/docs/esign-rest-api/reference/users/users/list/

I also see that the postman collection does not have a "counts" for this endpoint.

This could be the cause for the 400.