### PR TITLE
fix docusign dynamic base uri

### DIFF
--- a/cmd/baton-docusign/config.go
+++ b/cmd/baton-docusign/config.go
@@ -6,16 +6,10 @@ import (
 )
 
 var (
-	apiUrlField = field.StringField(
-		"api-url",
-		field.WithDescription("The base URL of the DocuSign API"),
-		field.WithDefaultValue("https://demo.docusign.net"),
-	)
-
-	accountField = field.StringField(
-		"account-id",
-		field.WithDescription("Your DocuSign account ID"),
-		field.WithRequired(true),
+	isDemoField = field.BoolField(
+		"demo",
+		field.WithDescription("Set to true for demo environment, false for production"),
+		field.WithDefaultValue(true),
 	)
 
 	clientIdField = field.StringField(
@@ -42,8 +36,7 @@ var (
 	)
 
 	ConfigurationFields = []field.SchemaField{
-		apiUrlField,
-		accountField,
+		isDemoField,
 		clientIdField,
 		clientSecretField,
 		redirectURIField,

--- a/cmd/baton-docusign/config.go
+++ b/cmd/baton-docusign/config.go
@@ -35,12 +35,19 @@ var (
 		field.WithRequired(true),
 	)
 
+	skipSigningGroupsField = field.BoolField(
+		"skip-signing-groups",
+		field.WithDescription("Set to true to skip syncing signing groups (for customers without signing groups feature enabled)"),
+		field.WithDefaultValue(false),
+	)
+
 	ConfigurationFields = []field.SchemaField{
 		isDemoField,
 		clientIdField,
 		clientSecretField,
 		redirectURIField,
 		refreshTokenField,
+		skipSigningGroupsField,
 	}
 
 	FieldRelationships = []field.SchemaFieldRelationship{}

--- a/cmd/baton-docusign/main.go
+++ b/cmd/baton-docusign/main.go
@@ -48,14 +48,13 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 		return nil, err
 	}
 
-	docusignApi := v.GetString(apiUrlField.FieldName)
-	docusignAccount := v.GetString(accountField.FieldName)
+	isDemo := v.GetBool(isDemoField.FieldName)
 	docusignClientId := v.GetString(clientIdField.FieldName)
 	docusignClientSecret := v.GetString(clientSecretField.FieldName)
 	docusignRedirectURI := v.GetString(redirectURIField.FieldName)
 	docusignRefreshToken := v.GetString(refreshTokenField.FieldName)
 
-	cb, err := connectorSchema.New(ctx, docusignApi, docusignAccount, docusignClientId, docusignClientSecret, docusignRedirectURI, docusignRefreshToken)
+	cb, err := connectorSchema.New(ctx, isDemo, docusignClientId, docusignClientSecret, docusignRedirectURI, docusignRefreshToken)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/cmd/baton-docusign/main.go
+++ b/cmd/baton-docusign/main.go
@@ -53,8 +53,9 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 	docusignClientSecret := v.GetString(clientSecretField.FieldName)
 	docusignRedirectURI := v.GetString(redirectURIField.FieldName)
 	docusignRefreshToken := v.GetString(refreshTokenField.FieldName)
+	skipSigningGroups := v.GetBool(skipSigningGroupsField.FieldName)
 
-	cb, err := connectorSchema.New(ctx, isDemo, docusignClientId, docusignClientSecret, docusignRedirectURI, docusignRefreshToken)
+	cb, err := connectorSchema.New(ctx, isDemo, docusignClientId, docusignClientSecret, docusignRedirectURI, docusignRefreshToken, skipSigningGroups)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -37,7 +37,6 @@ type Client struct {
 	userInfoCache *UserInfoCache
 	baseURI       string
 	accountId     string
-	initialized   bool
 }
 
 // New constructs a Client with OAuth2 flow, now using dynamic base URI resolution.
@@ -50,7 +49,6 @@ func New(ctx context.Context, isDemo bool, clientID, clientSecret, redirectURI, 
 		tokenSource:   tokenSource,
 		wrapper:       uhttp.NewBaseHttpClient(baseClient),
 		userInfoCache: NewUserInfoCache(),
-		initialized:   false,
 	}, nil
 }
 
@@ -69,7 +67,6 @@ func NewClient(ctx context.Context, isDemo bool, tokenSource oauth2.TokenSource,
 		tokenSource:   tokenSource,
 		wrapper:       wrapper,
 		userInfoCache: NewUserInfoCache(),
-		initialized:   false,
 	}
 }
 
@@ -103,10 +100,6 @@ func (c *Client) fetchUserInfo(ctx context.Context) (*UserInfoResponse, error) {
 
 // ensureInitialized ensures the client has fetched user info and set base URI.
 func (c *Client) ensureInitialized(ctx context.Context) error {
-	if c.initialized {
-		return nil
-	}
-
 	// Get token for TTL calculation
 	token, err := c.tokenSource.Token()
 	if err != nil {
@@ -156,7 +149,6 @@ func (c *Client) ensureInitialized(ctx context.Context) error {
 	// Set the base URI and account ID (from the selected account)
 	c.baseURI = selectedAccount.BaseURI
 	c.accountId = selectedAccount.AccountId
-	c.initialized = true
 
 	return nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -84,18 +84,18 @@ func (c *Client) fetchUserInfo(ctx context.Context) (*UserInfoResponse, error) {
 
 	userInfoURL, err := url.Parse(userInfoEndpoint)
 	if err != nil {
-		return nil, NewUserInfoError("invalid user info endpoint", err)
+		return nil, fmt.Errorf("invalid user info endpoint: %w", err)
 	}
 
 	var userInfo UserInfoResponse
 	_, _, err = c.doRequest(ctx, http.MethodGet, userInfoURL, &userInfo)
 	if err != nil {
 		// Wrap the error so baton-sdk can handle retries
-		return nil, NewUserInfoError("failed to fetch user info", err)
+		return nil, fmt.Errorf("failed to fetch user info: %w", err)
 	}
 
 	if len(userInfo.Accounts) == 0 {
-		return nil, NewUserInfoError("no accounts found in user info response", nil)
+		return nil, fmt.Errorf("no accounts found in user info response")
 	}
 
 	return &userInfo, nil
@@ -150,7 +150,7 @@ func (c *Client) ensureInitialized(ctx context.Context) error {
 	}
 
 	if selectedAccount == nil {
-		return NewUserInfoError("no valid account found in user info", nil)
+		return fmt.Errorf("no valid account found in user info")
 	}
 
 	// Set the base URI and account ID (from the selected account)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -142,8 +142,8 @@ func (c *Client) ensureInitialized(ctx context.Context) error {
 	return nil
 }
 
-// getClientURL safely reads baseURI and accountId to build a URL.
-func (c *Client) getClientURL(path string, params ...interface{}) (*url.URL, error) {
+// buildClientURL safely reads baseURI and accountId to build a URL.
+func (c *Client) buildClientURL(path string, params ...interface{}) (*url.URL, error) {
 	c.mutex.RLock()
 	baseURI := c.baseURI
 	accountId := c.accountId
@@ -152,22 +152,59 @@ func (c *Client) getClientURL(path string, params ...interface{}) (*url.URL, err
 	return buildURL(baseURI, path, append([]interface{}{accountId}, params...)...)
 }
 
-// getClientBaseURL safely reads baseURI for URL parsing.
-func (c *Client) getClientBaseURL() (*url.URL, error) {
+// prepareClientPagedRequest safely prepares a paged request URL with client's baseURI and accountId.
+func (c *Client) prepareClientPagedRequest(endpoint string, options PageOptions) (*url.URL, error) {
 	c.mutex.RLock()
 	baseURI := c.baseURI
-	c.mutex.RUnlock()
-
-	return url.Parse(baseURI)
-}
-
-// getClientAccountId safely reads accountId.
-func (c *Client) getClientAccountId() string {
-	c.mutex.RLock()
 	accountId := c.accountId
 	c.mutex.RUnlock()
 
-	return accountId
+	baseURL, err := url.Parse(baseURI)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL: %w", err)
+	}
+
+	return preparePagedRequest(baseURL, fmt.Sprintf(endpoint, accountId), options)
+}
+
+// prepareSigningGroupUsersRequest handles the special case for signing group users.
+func (c *Client) prepareSigningGroupUsersRequest(groupId string, options PageOptions) (*url.URL, error) {
+	c.mutex.RLock()
+	baseURI := c.baseURI
+	accountId := c.accountId
+	c.mutex.RUnlock()
+
+	baseURL, err := url.Parse(baseURI)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL: %w", err)
+	}
+
+	getSignedGroupDetailsURL, err := url.JoinPath(fmt.Sprintf(getSigningGroups, accountId), groupId)
+	if err != nil {
+		return nil, err
+	}
+
+	return preparePagedRequest(baseURL, getSignedGroupDetailsURL, options)
+}
+
+// buildPermissionProfilesURL handles the special case for permission profiles.
+func (c *Client) buildPermissionProfilesURL() (*url.URL, *url.URL, error) {
+	c.mutex.RLock()
+	baseURI := c.baseURI
+	accountId := c.accountId
+	c.mutex.RUnlock()
+
+	baseURL, err := url.Parse(baseURI)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid base URL: %w", err)
+	}
+
+	permissionProfilesURL, err := url.Parse(fmt.Sprintf(getPermissionProfiles, accountId))
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid endpoint: %w", err)
+	}
+
+	return baseURL, permissionProfilesURL, nil
 }
 
 // GetUsers fetches a page of users and returns users, next page token, and annotations.
@@ -178,12 +215,7 @@ func (c *Client) GetUsers(ctx context.Context, options PageOptions) ([]User, str
 
 	var usersResponse UsersResponse
 
-	baseURL, err := c.getClientBaseURL()
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
-	}
-
-	usersURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getUsers, c.getClientAccountId()), options)
+	usersURL, err := c.prepareClientPagedRequest(getUsers, options)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -206,12 +238,7 @@ func (c *Client) GetGroups(ctx context.Context, options PageOptions) ([]Group, s
 
 	var groupsResponse GroupsResponse
 
-	baseURL, err := c.getClientBaseURL()
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
-	}
-
-	groupsURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getGroups, c.getClientAccountId()), options)
+	groupsURL, err := c.prepareClientPagedRequest(getGroups, options)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -234,12 +261,7 @@ func (c *Client) GetGroupUsers(ctx context.Context, groupId string, options Page
 
 	var usersResponse UsersResponse
 
-	baseURL, err := c.getClientBaseURL()
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
-	}
-
-	groupUsersURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getGroupUsers, c.getClientAccountId(), groupId), options)
+	groupUsersURL, err := c.prepareClientPagedRequest(fmt.Sprintf(getGroupUsers, "%s", groupId), options)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -260,7 +282,7 @@ func (c *Client) GetUserDetails(ctx context.Context, userID string) (*UserDetail
 		return nil, nil, err
 	}
 
-	userURL, err := c.getClientURL(getPermissions, userID)
+	userURL, err := c.buildClientURL(getPermissions, userID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -284,7 +306,7 @@ func (c *Client) CreateUsers(ctx context.Context, request CreateUsersRequest) (*
 		return nil, nil, fmt.Errorf("at least one user must be provided")
 	}
 
-	createUsersURL, err := c.getClientURL(createUsers)
+	createUsersURL, err := c.buildClientURL(createUsers)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -305,12 +327,7 @@ func (c *Client) GetSigningGroups(ctx context.Context, options PageOptions) ([]S
 
 	var signingGroupsResponse SigningGroupResponse
 
-	baseURL, err := c.getClientBaseURL()
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
-	}
-
-	signingGroupsURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getSigningGroups, c.getClientAccountId()), options)
+	signingGroupsURL, err := c.prepareClientPagedRequest(getSigningGroups, options)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -332,17 +349,7 @@ func (c *Client) GetSigningGroupUsers(ctx context.Context, groupId string, optio
 
 	var groupMembersResponse UsersResponse
 
-	baseURL, err := c.getClientBaseURL()
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
-	}
-
-	getSignedGroupDetailsURL, err := url.JoinPath(fmt.Sprintf(getSigningGroups, c.getClientAccountId()), groupId)
-	if err != nil {
-		return nil, "", nil, err
-	}
-
-	signedGroupDetailsURL, err := preparePagedRequest(baseURL, getSignedGroupDetailsURL, options)
+	signedGroupDetailsURL, err := c.prepareSigningGroupUsersRequest(groupId, options)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -363,7 +370,7 @@ func (c *Client) GetUserByEmail(ctx context.Context, userEmail string) (*User, a
 		return nil, nil, err
 	}
 
-	userURL, err := c.getClientURL(getUsers)
+	userURL, err := c.buildClientURL(getUsers)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -391,14 +398,9 @@ func (c *Client) GetPermissionProfiles(ctx context.Context) ([]PermissionProfile
 
 	var permissionProfilesResponse PermissionProfilesResponse
 
-	baseURL, err := c.getClientBaseURL()
+	baseURL, permissionProfilesURL, err := c.buildPermissionProfilesURL()
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid base URL: %w", err)
-	}
-
-	permissionProfilesURL, err := url.Parse(fmt.Sprintf(getPermissionProfiles, c.getClientAccountId()))
-	if err != nil {
-		return nil, nil, fmt.Errorf("invalid endpoint: %w", err)
+		return nil, nil, err
 	}
 
 	permissionProfilesURL = baseURL.ResolveReference(permissionProfilesURL)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -31,12 +32,14 @@ const (
 
 // Client wraps HTTP interactions with the DocuSign API, handling auth and base URL.
 type Client struct {
-	isDemo        bool
-	tokenSource   oauth2.TokenSource
-	wrapper       *uhttp.BaseHttpClient
-	userInfoCache *UserInfoCache
-	baseURI       string
-	accountId     string
+	isDemo         bool
+	tokenSource    oauth2.TokenSource
+	wrapper        *uhttp.BaseHttpClient
+	baseURI        string
+	accountId      string
+	userInfo       *UserInfoResponse
+	userInfoExpiry time.Time
+	mutex          sync.RWMutex // protects baseURI, accountId, userInfo, and userInfoExpiry
 }
 
 // New constructs a Client with OAuth2 flow, now using dynamic base URI resolution.
@@ -45,10 +48,9 @@ func New(ctx context.Context, isDemo bool, clientID, clientSecret, redirectURI, 
 	baseClient := oauth2.NewClient(ctx, tokenSource)
 
 	return &Client{
-		isDemo:        isDemo,
-		tokenSource:   tokenSource,
-		wrapper:       uhttp.NewBaseHttpClient(baseClient),
-		userInfoCache: NewUserInfoCache(),
+		isDemo:      isDemo,
+		tokenSource: tokenSource,
+		wrapper:     uhttp.NewBaseHttpClient(baseClient),
 	}, nil
 }
 
@@ -63,10 +65,9 @@ func NewClient(ctx context.Context, isDemo bool, tokenSource oauth2.TokenSource,
 	}
 
 	return &Client{
-		isDemo:        isDemo,
-		tokenSource:   tokenSource,
-		wrapper:       wrapper,
-		userInfoCache: NewUserInfoCache(),
+		isDemo:      isDemo,
+		tokenSource: tokenSource,
+		wrapper:     wrapper,
 	}
 }
 
@@ -100,30 +101,16 @@ func (c *Client) fetchUserInfo(ctx context.Context) (*UserInfoResponse, error) {
 
 // ensureInitialized ensures the client has fetched user info and set base URI.
 func (c *Client) ensureInitialized(ctx context.Context) error {
-	// Get token for TTL calculation
-	token, err := c.tokenSource.Token()
-	if err != nil {
-		return fmt.Errorf("failed to get token: %w", err)
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	// Check if we have valid cached user info
+	if c.userInfo != nil && time.Now().Before(c.userInfoExpiry) {
+		return nil
 	}
 
-	// Create fetch function
-	fetchFunc := func() (*UserInfoResponse, time.Duration, error) {
-		userInfo, err := c.fetchUserInfo(ctx)
-		if err != nil {
-			return nil, 0, err
-		}
-
-		// Calculate TTL based on token expiry (minus 5 minutes for safety)
-		ttl := time.Until(token.Expiry) - 5*time.Minute
-		if ttl <= 0 {
-			ttl = 5 * time.Minute // minimum cache time
-		}
-
-		return userInfo, ttl, nil
-	}
-
-	// Get or fetch user info
-	userInfo, err := c.userInfoCache.GetOrFetch(fetchFunc)
+	// Fetch fresh user info
+	userInfo, err := c.fetchUserInfo(ctx)
 	if err != nil {
 		return err
 	}
@@ -146,11 +133,41 @@ func (c *Client) ensureInitialized(ctx context.Context) error {
 		return fmt.Errorf("no valid account found in user info")
 	}
 
-	// Set the base URI and account ID (from the selected account)
+	// Update cached values with 1-hour expiry
+	c.userInfo = userInfo
+	c.userInfoExpiry = time.Now().Add(1 * time.Hour)
 	c.baseURI = selectedAccount.BaseURI
 	c.accountId = selectedAccount.AccountId
 
 	return nil
+}
+
+// getClientURL safely reads baseURI and accountId to build a URL.
+func (c *Client) getClientURL(path string, params ...interface{}) (*url.URL, error) {
+	c.mutex.RLock()
+	baseURI := c.baseURI
+	accountId := c.accountId
+	c.mutex.RUnlock()
+
+	return buildURL(baseURI, path, append([]interface{}{accountId}, params...)...)
+}
+
+// getClientBaseURL safely reads baseURI for URL parsing.
+func (c *Client) getClientBaseURL() (*url.URL, error) {
+	c.mutex.RLock()
+	baseURI := c.baseURI
+	c.mutex.RUnlock()
+
+	return url.Parse(baseURI)
+}
+
+// getClientAccountId safely reads accountId.
+func (c *Client) getClientAccountId() string {
+	c.mutex.RLock()
+	accountId := c.accountId
+	c.mutex.RUnlock()
+
+	return accountId
 }
 
 // GetUsers fetches a page of users and returns users, next page token, and annotations.
@@ -161,12 +178,12 @@ func (c *Client) GetUsers(ctx context.Context, options PageOptions) ([]User, str
 
 	var usersResponse UsersResponse
 
-	baseURL, err := url.Parse(c.baseURI)
+	baseURL, err := c.getClientBaseURL()
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
 	}
 
-	usersURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getUsers, c.accountId), options)
+	usersURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getUsers, c.getClientAccountId()), options)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -189,12 +206,12 @@ func (c *Client) GetGroups(ctx context.Context, options PageOptions) ([]Group, s
 
 	var groupsResponse GroupsResponse
 
-	baseURL, err := url.Parse(c.baseURI)
+	baseURL, err := c.getClientBaseURL()
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
 	}
 
-	groupsURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getGroups, c.accountId), options)
+	groupsURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getGroups, c.getClientAccountId()), options)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -217,12 +234,12 @@ func (c *Client) GetGroupUsers(ctx context.Context, groupId string, options Page
 
 	var usersResponse UsersResponse
 
-	baseURL, err := url.Parse(c.baseURI)
+	baseURL, err := c.getClientBaseURL()
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
 	}
 
-	groupUsersURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getGroupUsers, c.accountId, groupId), options)
+	groupUsersURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getGroupUsers, c.getClientAccountId(), groupId), options)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -243,7 +260,7 @@ func (c *Client) GetUserDetails(ctx context.Context, userID string) (*UserDetail
 		return nil, nil, err
 	}
 
-	userURL, err := buildURL(c.baseURI, getPermissions, c.accountId, userID)
+	userURL, err := c.getClientURL(getPermissions, userID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -267,7 +284,7 @@ func (c *Client) CreateUsers(ctx context.Context, request CreateUsersRequest) (*
 		return nil, nil, fmt.Errorf("at least one user must be provided")
 	}
 
-	createUsersURL, err := buildURL(c.baseURI, createUsers, c.accountId)
+	createUsersURL, err := c.getClientURL(createUsers)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -288,12 +305,12 @@ func (c *Client) GetSigningGroups(ctx context.Context, options PageOptions) ([]S
 
 	var signingGroupsResponse SigningGroupResponse
 
-	baseURL, err := url.Parse(c.baseURI)
+	baseURL, err := c.getClientBaseURL()
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
 	}
 
-	signingGroupsURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getSigningGroups, c.accountId), options)
+	signingGroupsURL, err := preparePagedRequest(baseURL, fmt.Sprintf(getSigningGroups, c.getClientAccountId()), options)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -315,12 +332,12 @@ func (c *Client) GetSigningGroupUsers(ctx context.Context, groupId string, optio
 
 	var groupMembersResponse UsersResponse
 
-	baseURL, err := url.Parse(c.baseURI)
+	baseURL, err := c.getClientBaseURL()
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
 	}
 
-	getSignedGroupDetailsURL, err := url.JoinPath(fmt.Sprintf(getSigningGroups, c.accountId), groupId)
+	getSignedGroupDetailsURL, err := url.JoinPath(fmt.Sprintf(getSigningGroups, c.getClientAccountId()), groupId)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -346,7 +363,7 @@ func (c *Client) GetUserByEmail(ctx context.Context, userEmail string) (*User, a
 		return nil, nil, err
 	}
 
-	userURL, err := buildURL(c.baseURI, getUsers, c.accountId)
+	userURL, err := c.getClientURL(getUsers)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -374,12 +391,12 @@ func (c *Client) GetPermissionProfiles(ctx context.Context) ([]PermissionProfile
 
 	var permissionProfilesResponse PermissionProfilesResponse
 
-	baseURL, err := url.Parse(c.baseURI)
+	baseURL, err := c.getClientBaseURL()
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid base URL: %w", err)
 	}
 
-	permissionProfilesURL, err := url.Parse(fmt.Sprintf(getPermissionProfiles, c.accountId))
+	permissionProfilesURL, err := url.Parse(fmt.Sprintf(getPermissionProfiles, c.getClientAccountId()))
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid endpoint: %w", err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
@@ -22,29 +23,39 @@ const (
 	getPermissionProfiles = "/restapi/v2.1/accounts/%s/permission_profiles"
 )
 
+// OAuth User Info endpoints.
+const (
+	userInfoEndpointDemo = "https://account-d.docusign.com/oauth/userinfo"
+	userInfoEndpointProd = "https://account.docusign.com/oauth/userinfo"
+)
+
 // Client wraps HTTP interactions with the DocuSign API, handling auth and base URL.
 type Client struct {
-	apiUrl      string
-	tokenSource oauth2.TokenSource
-	accountId   string
-	wrapper     *uhttp.BaseHttpClient
+	isDemo        bool
+	tokenSource   oauth2.TokenSource
+	wrapper       *uhttp.BaseHttpClient
+	userInfoCache *UserInfoCache
+	baseURI       string
+	accountId     string
+	initialized   bool
 }
 
-// New constructs a Client, choosing OAuth2 interactive flow or direct token based on accessToken.
-func New(ctx context.Context, apiUrl, accountId, clientID, clientSecret, redirectURI, refreshToken string) (*Client, error) {
+// New constructs a Client with OAuth2 flow, now using dynamic base URI resolution.
+func New(ctx context.Context, isDemo bool, clientID, clientSecret, redirectURI, refreshToken string) (*Client, error) {
 	tokenSource := getTokenSource(ctx, clientID, clientSecret, redirectURI, refreshToken)
 	baseClient := oauth2.NewClient(ctx, tokenSource)
 
 	return &Client{
-		apiUrl:      apiUrl,
-		tokenSource: tokenSource,
-		accountId:   accountId,
-		wrapper:     uhttp.NewBaseHttpClient(baseClient),
+		isDemo:        isDemo,
+		tokenSource:   tokenSource,
+		wrapper:       uhttp.NewBaseHttpClient(baseClient),
+		userInfoCache: NewUserInfoCache(),
+		initialized:   false,
 	}, nil
 }
 
 // NewClient initializes a Client with a fixed token and optional HTTP wrapper.
-func NewClient(ctx context.Context, apiUrl, accountId string, tokenSource oauth2.TokenSource, httpClient ...*uhttp.BaseHttpClient) *Client {
+func NewClient(ctx context.Context, isDemo bool, tokenSource oauth2.TokenSource, httpClient ...*uhttp.BaseHttpClient) *Client {
 	var wrapper *uhttp.BaseHttpClient
 	if len(httpClient) > 0 {
 		wrapper = httpClient[0]
@@ -54,18 +65,132 @@ func NewClient(ctx context.Context, apiUrl, accountId string, tokenSource oauth2
 	}
 
 	return &Client{
-		apiUrl:      apiUrl,
-		tokenSource: tokenSource,
-		accountId:   accountId,
-		wrapper:     wrapper,
+		isDemo:        isDemo,
+		tokenSource:   tokenSource,
+		wrapper:       wrapper,
+		userInfoCache: NewUserInfoCache(),
+		initialized:   false,
 	}
+}
+
+// fetchUserInfo calls the DocuSign OAuth User Info endpoint to get account details.
+func (c *Client) fetchUserInfo(ctx context.Context) (*UserInfoResponse, error) {
+	var userInfoEndpoint string
+	if c.isDemo {
+		userInfoEndpoint = userInfoEndpointDemo
+	} else {
+		userInfoEndpoint = userInfoEndpointProd
+	}
+
+	userInfoURL, err := url.Parse(userInfoEndpoint)
+	if err != nil {
+		return nil, NewUserInfoError("invalid user info endpoint", err)
+	}
+
+	// Retry logic for transient failures
+	maxRetries := 3
+	var lastErr error
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		var userInfo UserInfoResponse
+		_, _, err = c.doRequest(ctx, http.MethodGet, userInfoURL, &userInfo)
+		if err == nil {
+			// Success
+			if len(userInfo.Accounts) == 0 {
+				return nil, NewUserInfoError("no accounts found in user info response", nil)
+			}
+			return &userInfo, nil
+		}
+
+		lastErr = err
+
+		// If this is not the last attempt, wait before retrying
+		if attempt < maxRetries-1 {
+			select {
+			case <-ctx.Done():
+				return nil, NewUserInfoError("context cancelled during retry", ctx.Err())
+			case <-time.After(time.Duration(attempt+1) * time.Second):
+				// Continue to next attempt
+			}
+		}
+	}
+
+	return nil, NewUserInfoError("failed to fetch user info after retries", lastErr)
+}
+
+// ensureInitialized ensures the client has fetched user info and set base URI.
+func (c *Client) ensureInitialized(ctx context.Context) error {
+	if c.initialized {
+		return nil
+	}
+
+	// Create a cache key based on token (we'll use the token itself as key)
+	token, err := c.tokenSource.Token()
+	if err != nil {
+		return fmt.Errorf("failed to get token: %w", err)
+	}
+
+	// Use a safe substring for the cache key
+	accessToken := token.AccessToken
+	if len(accessToken) > 20 {
+		accessToken = accessToken[:20]
+	}
+	cacheKey := fmt.Sprintf("userinfo_%s", accessToken)
+
+	// Try to get cached user info
+	userInfo, found := c.userInfoCache.Get(cacheKey)
+	if !found {
+		// Fetch fresh user info
+		userInfo, err = c.fetchUserInfo(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Calculate TTL based on token expiry (minus 5 minutes for safety)
+		ttl := time.Until(token.Expiry) - 5*time.Minute
+		if ttl <= 0 {
+			ttl = 5 * time.Minute // minimum cache time
+		}
+
+		// Cache the user info
+		c.userInfoCache.Set(cacheKey, userInfo, ttl)
+	}
+
+	// Find the appropriate account
+	var selectedAccount *AccountInfo
+	for _, account := range userInfo.Accounts {
+		if account.IsDefault {
+			selectedAccount = &account
+			break
+		}
+	}
+
+	// If no default account, use the first one
+	if selectedAccount == nil && len(userInfo.Accounts) > 0 {
+		selectedAccount = &userInfo.Accounts[0]
+	}
+
+	if selectedAccount == nil {
+		return NewUserInfoError("no valid account found in user info", nil)
+	}
+
+	// Set the base URI and account ID
+	c.baseURI = selectedAccount.BaseURI
+	c.accountId = selectedAccount.AccountId
+	c.initialized = true
+
+	return nil
 }
 
 // GetUsers fetches a page of users and returns users, next page token, and annotations.
 func (c *Client) GetUsers(ctx context.Context, options PageOptions) ([]User, string, annotations.Annotations, error) {
+	if err := c.ensureInitialized(ctx); err != nil {
+		return nil, "", nil, err
+	}
+
 	var usersResponse UsersResponse
 
-	baseURL, err := url.Parse(c.apiUrl)
+	baseURL, err := url.Parse(c.baseURI)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
 	}
@@ -87,9 +212,13 @@ func (c *Client) GetUsers(ctx context.Context, options PageOptions) ([]User, str
 
 // GetGroups fetches a page of groups and handles pagination and rate limit annotations.
 func (c *Client) GetGroups(ctx context.Context, options PageOptions) ([]Group, string, annotations.Annotations, error) {
+	if err := c.ensureInitialized(ctx); err != nil {
+		return nil, "", nil, err
+	}
+
 	var groupsResponse GroupsResponse
 
-	baseURL, err := url.Parse(c.apiUrl)
+	baseURL, err := url.Parse(c.baseURI)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
 	}
@@ -111,9 +240,13 @@ func (c *Client) GetGroups(ctx context.Context, options PageOptions) ([]Group, s
 
 // GetGroupUsers fetches users for a group with pagination support.
 func (c *Client) GetGroupUsers(ctx context.Context, groupId string, options PageOptions) ([]User, string, annotations.Annotations, error) {
+	if err := c.ensureInitialized(ctx); err != nil {
+		return nil, "", nil, err
+	}
+
 	var usersResponse UsersResponse
 
-	baseURL, err := url.Parse(c.apiUrl)
+	baseURL, err := url.Parse(c.baseURI)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
 	}
@@ -135,7 +268,11 @@ func (c *Client) GetGroupUsers(ctx context.Context, groupId string, options Page
 
 // GetUserDetails fetches detailed information for a specific user, including permissions.
 func (c *Client) GetUserDetails(ctx context.Context, userID string) (*UserDetail, annotations.Annotations, error) {
-	userURL, err := buildURL(c.apiUrl, getPermissions, c.accountId, userID)
+	if err := c.ensureInitialized(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	userURL, err := buildURL(c.baseURI, getPermissions, c.accountId, userID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -151,11 +288,15 @@ func (c *Client) GetUserDetails(ctx context.Context, userID string) (*UserDetail
 
 // CreateUsers sends a bulk create request for new users in the account.
 func (c *Client) CreateUsers(ctx context.Context, request CreateUsersRequest) (*UserCreationResponse, annotations.Annotations, error) {
+	if err := c.ensureInitialized(ctx); err != nil {
+		return nil, nil, err
+	}
+
 	if len(request.NewUsers) == 0 {
 		return nil, nil, fmt.Errorf("at least one user must be provided")
 	}
 
-	createUsersURL, err := buildURL(c.apiUrl, createUsers, c.accountId)
+	createUsersURL, err := buildURL(c.baseURI, createUsers, c.accountId)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -170,9 +311,13 @@ func (c *Client) CreateUsers(ctx context.Context, request CreateUsersRequest) (*
 }
 
 func (c *Client) GetSigningGroups(ctx context.Context, options PageOptions) ([]SigningGroup, string, annotations.Annotations, error) {
+	if err := c.ensureInitialized(ctx); err != nil {
+		return nil, "", nil, err
+	}
+
 	var signingGroupsResponse SigningGroupResponse
 
-	baseURL, err := url.Parse(c.apiUrl)
+	baseURL, err := url.Parse(c.baseURI)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
 	}
@@ -193,9 +338,13 @@ func (c *Client) GetSigningGroups(ctx context.Context, options PageOptions) ([]S
 }
 
 func (c *Client) GetSigningGroupUsers(ctx context.Context, groupId string, options PageOptions) ([]User, string, annotations.Annotations, error) {
+	if err := c.ensureInitialized(ctx); err != nil {
+		return nil, "", nil, err
+	}
+
 	var groupMembersResponse UsersResponse
 
-	baseURL, err := url.Parse(c.apiUrl)
+	baseURL, err := url.Parse(c.baseURI)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("invalid base URL: %w", err)
 	}
@@ -222,7 +371,11 @@ func (c *Client) GetSigningGroupUsers(ctx context.Context, groupId string, optio
 
 // GetUserByEmail retrieves a user filtering by the email and the user status 'Active' or 'Activation Sent'.
 func (c *Client) GetUserByEmail(ctx context.Context, userEmail string) (*User, annotations.Annotations, error) {
-	userURL, err := buildURL(c.apiUrl, getUsers, c.accountId)
+	if err := c.ensureInitialized(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	userURL, err := buildURL(c.baseURI, getUsers, c.accountId)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -244,9 +397,13 @@ func (c *Client) GetUserByEmail(ctx context.Context, userEmail string) (*User, a
 }
 
 func (c *Client) GetPermissionProfiles(ctx context.Context) ([]PermissionProfile, annotations.Annotations, error) {
+	if err := c.ensureInitialized(ctx); err != nil {
+		return nil, nil, err
+	}
+
 	var permissionProfilesResponse PermissionProfilesResponse
 
-	baseURL, err := url.Parse(c.apiUrl)
+	baseURL, err := url.Parse(c.baseURI)
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid base URL: %w", err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -137,13 +137,11 @@ func (c *Client) ensureInitialized(ctx context.Context) error {
 	}
 	cacheKey := fmt.Sprintf("userinfo_%s", accessToken)
 
-	// Try to get cached user info
-	userInfo, found := c.userInfoCache.Get(cacheKey)
-	if !found {
-		// Fetch fresh user info
-		userInfo, err = c.fetchUserInfo(ctx)
+	// Create fetch function that captures the context and token
+	fetchFunc := func() (*UserInfoResponse, time.Duration, error) {
+		userInfo, err := c.fetchUserInfo(ctx)
 		if err != nil {
-			return err
+			return nil, 0, err
 		}
 
 		// Calculate TTL based on token expiry (minus 5 minutes for safety)
@@ -152,8 +150,13 @@ func (c *Client) ensureInitialized(ctx context.Context) error {
 			ttl = 5 * time.Minute // minimum cache time
 		}
 
-		// Cache the user info
-		c.userInfoCache.Set(cacheKey, userInfo, ttl)
+		return userInfo, ttl, nil
+	}
+
+	// Get or fetch user info
+	userInfo, err := c.userInfoCache.GetOrFetch(cacheKey, fetchFunc)
+	if err != nil {
+		return err
 	}
 
 	// Find the appropriate account

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -107,20 +107,13 @@ func (c *Client) ensureInitialized(ctx context.Context) error {
 		return nil
 	}
 
-	// Create a cache key based on token (we'll use the token itself as key)
+	// Get token for TTL calculation
 	token, err := c.tokenSource.Token()
 	if err != nil {
 		return fmt.Errorf("failed to get token: %w", err)
 	}
 
-	// Use a safe substring for the cache key
-	accessToken := token.AccessToken
-	if len(accessToken) > 20 {
-		accessToken = accessToken[:20]
-	}
-	cacheKey := fmt.Sprintf("userinfo_%s", accessToken)
-
-	// Create fetch function that captures the context and token
+	// Create fetch function
 	fetchFunc := func() (*UserInfoResponse, time.Duration, error) {
 		userInfo, err := c.fetchUserInfo(ctx)
 		if err != nil {
@@ -137,7 +130,7 @@ func (c *Client) ensureInitialized(ctx context.Context) error {
 	}
 
 	// Get or fetch user info
-	userInfo, err := c.userInfoCache.GetOrFetch(cacheKey, fetchFunc)
+	userInfo, err := c.userInfoCache.GetOrFetch(fetchFunc)
 	if err != nil {
 		return err
 	}
@@ -160,7 +153,7 @@ func (c *Client) ensureInitialized(ctx context.Context) error {
 		return NewUserInfoError("no valid account found in user info", nil)
 	}
 
-	// Set the base URI and account ID
+	// Set the base URI and account ID (from the selected account)
 	c.baseURI = selectedAccount.BaseURI
 	c.accountId = selectedAccount.AccountId
 	c.initialized = true

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -87,35 +87,18 @@ func (c *Client) fetchUserInfo(ctx context.Context) (*UserInfoResponse, error) {
 		return nil, NewUserInfoError("invalid user info endpoint", err)
 	}
 
-	// Retry logic for transient failures
-	maxRetries := 3
-	var lastErr error
-
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		var userInfo UserInfoResponse
-		_, _, err = c.doRequest(ctx, http.MethodGet, userInfoURL, &userInfo)
-		if err == nil {
-			// Success
-			if len(userInfo.Accounts) == 0 {
-				return nil, NewUserInfoError("no accounts found in user info response", nil)
-			}
-			return &userInfo, nil
-		}
-
-		lastErr = err
-
-		// If this is not the last attempt, wait before retrying
-		if attempt < maxRetries-1 {
-			select {
-			case <-ctx.Done():
-				return nil, NewUserInfoError("context cancelled during retry", ctx.Err())
-			case <-time.After(time.Duration(attempt+1) * time.Second):
-				// Continue to next attempt
-			}
-		}
+	var userInfo UserInfoResponse
+	_, _, err = c.doRequest(ctx, http.MethodGet, userInfoURL, &userInfo)
+	if err != nil {
+		// Wrap the error so baton-sdk can handle retries
+		return nil, NewUserInfoError("failed to fetch user info", err)
 	}
 
-	return nil, NewUserInfoError("failed to fetch user info after retries", lastErr)
+	if len(userInfo.Accounts) == 0 {
+		return nil, NewUserInfoError("no accounts found in user info response", nil)
+	}
+
+	return &userInfo, nil
 }
 
 // ensureInitialized ensures the client has fetched user info and set base URI.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -38,12 +38,29 @@ func createTestServer(t *testing.T, mockResponse string, urlPath string, method 
 	}))
 }
 
-// Helper function to create a new client instance.
-func createClient(baseURL string) *client.Client {
+// Helper function to create a new client instance with test server response.
+func createClient(baseURL string, mockResponse string, urlPath string) *client.Client {
+	// Create headers for JSON response
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	// Create a mock transport that handles both User Info and API endpoints
+	mockTransport := &test.MultiEndpointMockTransport{
+		Responses: map[string]*http.Response{
+			baseURL + urlPath: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     header,
+				Body:       test.CreateMockResponseBody(mockResponse),
+			},
+		},
+		Errors: map[string]error{},
+	}
+
+	httpClient := &http.Client{Transport: mockTransport}
+	baseHttpClient := uhttp.NewBaseHttpClient(httpClient)
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: test.MockAccessToken})
-	oauthClient := oauth2.NewClient(context.Background(), ts)
-	baseHttpClient := uhttp.NewBaseHttpClient(oauthClient)
-	return client.NewClient(context.Background(), baseURL, test.MockAccountID, ts, baseHttpClient)
+
+	return client.NewClient(context.Background(), true, ts, baseHttpClient)
 }
 
 // Test case to verify successful retrieval of users without pagination.
@@ -54,7 +71,7 @@ func TestClient_GetUsers(t *testing.T) {
 
 		defer testServer.Close()
 
-		c := createClient(testServer.URL)
+		c := createClient(testServer.URL, "users_list.json", getUsersTest)
 		users, _, _, err := c.GetUsers(context.Background(), client.PageOptions{})
 
 		require.NoError(t, err)
@@ -72,7 +89,7 @@ func TestClient_GetUserDetails(t *testing.T) {
 
 		defer testServer.Close()
 
-		c := createClient(testServer.URL)
+		c := createClient(testServer.URL, "user_details.json", getUserDetailsTest)
 		userDetails, _, err := c.GetUserDetails(context.Background(), test.MockUserID)
 
 		require.NoError(t, err)
@@ -89,7 +106,7 @@ func TestClient_GetGroups(t *testing.T) {
 
 		defer testServer.Close()
 
-		c := createClient(testServer.URL)
+		c := createClient(testServer.URL, "groups.json", getGroupsTest)
 		groups, _, _, err := c.GetGroups(context.Background(), client.PageOptions{})
 
 		require.NoError(t, err)
@@ -106,7 +123,7 @@ func TestClient_GetGroupUsers(t *testing.T) {
 
 		defer testServer.Close()
 
-		c := createClient(testServer.URL)
+		c := createClient(testServer.URL, "group_users.json", getGroupUsersTest)
 		users, _, _, err := c.GetGroupUsers(context.Background(), test.MockGroupID, client.PageOptions{})
 
 		require.NoError(t, err)
@@ -122,7 +139,7 @@ func TestClient_CreateUsers(t *testing.T) {
 
 		defer testServer.Close()
 
-		c := createClient(testServer.URL)
+		c := createClient(testServer.URL, "create_users.json", getUsersTest)
 		req := client.CreateUsersRequest{
 			NewUsers: []client.NewUser{
 				{UserName: "newuser1", Email: "newuser1@test.com"},

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
+	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/ratelimit"
@@ -115,4 +117,79 @@ func ApplyQueryParam(reqURL *url.URL, key string, value string) {
 	q := reqURL.Query()
 	q.Set(key, value)
 	reqURL.RawQuery = q.Encode()
+}
+
+// CacheItem holds cached User Info data with expiry time.
+type CacheItem struct {
+	UserInfo  *UserInfoResponse
+	ExpiresAt time.Time
+}
+
+// UserInfoCache provides thread-safe caching for User Info responses.
+type UserInfoCache struct {
+	cache map[string]*CacheItem
+	mutex sync.RWMutex
+}
+
+// NewUserInfoCache creates a new UserInfoCache instance.
+func NewUserInfoCache() *UserInfoCache {
+	cache := &UserInfoCache{
+		cache: make(map[string]*CacheItem),
+	}
+
+	// Start cleanup goroutine to remove expired entries
+	go cache.cleanup()
+
+	return cache
+}
+
+// Set stores User Info data in the cache with TTL.
+func (c *UserInfoCache) Set(key string, userInfo *UserInfoResponse, ttl time.Duration) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.cache[key] = &CacheItem{
+		UserInfo:  userInfo,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+}
+
+// Get retrieves User Info data from the cache if not expired.
+func (c *UserInfoCache) Get(key string) (*UserInfoResponse, bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	item, exists := c.cache[key]
+	if !exists {
+		return nil, false
+	}
+
+	if time.Now().After(item.ExpiresAt) {
+		// Item expired, clean it up
+		go func() {
+			c.mutex.Lock()
+			defer c.mutex.Unlock()
+			delete(c.cache, key)
+		}()
+		return nil, false
+	}
+
+	return item.UserInfo, true
+}
+
+// cleanup removes expired entries from the cache periodically.
+func (c *UserInfoCache) cleanup() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		c.mutex.Lock()
+		now := time.Now()
+		for key, item := range c.cache {
+			if now.After(item.ExpiresAt) {
+				delete(c.cache, key)
+			}
+		}
+		c.mutex.Unlock()
+	}
 }

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -125,6 +125,9 @@ type CacheItem struct {
 	ExpiresAt time.Time
 }
 
+// FetchFunc is a function type for fetching User Info data.
+type FetchFunc func() (*UserInfoResponse, time.Duration, error)
+
 // UserInfoCache provides thread-safe caching for User Info responses.
 type UserInfoCache struct {
 	cache map[string]*CacheItem
@@ -133,63 +136,47 @@ type UserInfoCache struct {
 
 // NewUserInfoCache creates a new UserInfoCache instance.
 func NewUserInfoCache() *UserInfoCache {
-	cache := &UserInfoCache{
+	return &UserInfoCache{
 		cache: make(map[string]*CacheItem),
 	}
-
-	// Start cleanup goroutine to remove expired entries
-	go cache.cleanup()
-
-	return cache
 }
 
-// Set stores User Info data in the cache with TTL.
-func (c *UserInfoCache) Set(key string, userInfo *UserInfoResponse, ttl time.Duration) {
+// GetOrFetch retrieves User Info data from cache or fetches it if not present/expired.
+func (c *UserInfoCache) GetOrFetch(key string, fetchFunc FetchFunc) (*UserInfoResponse, error) {
+	// First, try to get from cache with read lock
+	c.mutex.RLock()
+	item, exists := c.cache[key]
+	if exists && time.Now().Before(item.ExpiresAt) {
+		// Cache hit and not expired
+		userInfo := item.UserInfo
+		c.mutex.RUnlock()
+		return userInfo, nil
+	}
+	c.mutex.RUnlock()
+
+	// Cache miss or expired - need to fetch with write lock
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
+	// Double-check in case another goroutine fetched while we waited for write lock
+	item, exists = c.cache[key]
+	if exists && time.Now().Before(item.ExpiresAt) {
+		return item.UserInfo, nil
+	}
+
+	// Fetch new data
+	userInfo, ttl, err := fetchFunc()
+	if err != nil {
+		// Remove expired item on fetch failure
+		delete(c.cache, key)
+		return nil, err
+	}
+
+	// Store in cache
 	c.cache[key] = &CacheItem{
 		UserInfo:  userInfo,
 		ExpiresAt: time.Now().Add(ttl),
 	}
-}
 
-// Get retrieves User Info data from the cache if not expired.
-func (c *UserInfoCache) Get(key string) (*UserInfoResponse, bool) {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
-	item, exists := c.cache[key]
-	if !exists {
-		return nil, false
-	}
-
-	if time.Now().After(item.ExpiresAt) {
-		// Item expired, clean it up
-		go func() {
-			c.mutex.Lock()
-			defer c.mutex.Unlock()
-			delete(c.cache, key)
-		}()
-		return nil, false
-	}
-
-	return item.UserInfo, true
-}
-
-// cleanup removes expired entries from the cache periodically.
-func (c *UserInfoCache) cleanup() {
-	ticker := time.NewTicker(5 * time.Minute)
-	defer ticker.Stop()
-
-	for range ticker.C {
-		c.mutex.Lock()
-		now := time.Now()
-		for key, item := range c.cache {
-			if now.After(item.ExpiresAt) {
-				delete(c.cache, key)
-			}
-		}
-		c.mutex.Unlock()
-	}
+	return userInfo, nil
 }

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"sync"
-	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/ratelimit"
@@ -117,62 +115,4 @@ func ApplyQueryParam(reqURL *url.URL, key string, value string) {
 	q := reqURL.Query()
 	q.Set(key, value)
 	reqURL.RawQuery = q.Encode()
-}
-
-// CacheItem holds cached User Info data with expiry time.
-type CacheItem struct {
-	UserInfo  *UserInfoResponse
-	ExpiresAt time.Time
-}
-
-// FetchFunc is a function type for fetching User Info data.
-type FetchFunc func() (*UserInfoResponse, time.Duration, error)
-
-// UserInfoCache provides thread-safe caching for User Info responses.
-type UserInfoCache struct {
-	item  *CacheItem
-	mutex sync.RWMutex
-}
-
-// NewUserInfoCache creates a new UserInfoCache instance.
-func NewUserInfoCache() *UserInfoCache {
-	return &UserInfoCache{}
-}
-
-// GetOrFetch retrieves User Info data from cache or fetches it if not present/expired.
-func (c *UserInfoCache) GetOrFetch(fetchFunc FetchFunc) (*UserInfoResponse, error) {
-	// First, try to get from cache with read lock
-	c.mutex.RLock()
-	if c.item != nil && time.Now().Before(c.item.ExpiresAt) {
-		// Cache hit and not expired
-		userInfo := c.item.UserInfo
-		c.mutex.RUnlock()
-		return userInfo, nil
-	}
-	c.mutex.RUnlock()
-
-	// Cache miss or expired - need to fetch with write lock
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	// Double-check in case another goroutine fetched while we waited for write lock
-	if c.item != nil && time.Now().Before(c.item.ExpiresAt) {
-		return c.item.UserInfo, nil
-	}
-
-	// Fetch new data
-	userInfo, ttl, err := fetchFunc()
-	if err != nil {
-		// Clear expired item on fetch failure
-		c.item = nil
-		return nil, err
-	}
-
-	// Store in cache
-	c.item = &CacheItem{
-		UserInfo:  userInfo,
-		ExpiresAt: time.Now().Add(ttl),
-	}
-
-	return userInfo, nil
 }

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -130,25 +130,22 @@ type FetchFunc func() (*UserInfoResponse, time.Duration, error)
 
 // UserInfoCache provides thread-safe caching for User Info responses.
 type UserInfoCache struct {
-	cache map[string]*CacheItem
+	item  *CacheItem
 	mutex sync.RWMutex
 }
 
 // NewUserInfoCache creates a new UserInfoCache instance.
 func NewUserInfoCache() *UserInfoCache {
-	return &UserInfoCache{
-		cache: make(map[string]*CacheItem),
-	}
+	return &UserInfoCache{}
 }
 
 // GetOrFetch retrieves User Info data from cache or fetches it if not present/expired.
-func (c *UserInfoCache) GetOrFetch(key string, fetchFunc FetchFunc) (*UserInfoResponse, error) {
+func (c *UserInfoCache) GetOrFetch(fetchFunc FetchFunc) (*UserInfoResponse, error) {
 	// First, try to get from cache with read lock
 	c.mutex.RLock()
-	item, exists := c.cache[key]
-	if exists && time.Now().Before(item.ExpiresAt) {
+	if c.item != nil && time.Now().Before(c.item.ExpiresAt) {
 		// Cache hit and not expired
-		userInfo := item.UserInfo
+		userInfo := c.item.UserInfo
 		c.mutex.RUnlock()
 		return userInfo, nil
 	}
@@ -159,21 +156,20 @@ func (c *UserInfoCache) GetOrFetch(key string, fetchFunc FetchFunc) (*UserInfoRe
 	defer c.mutex.Unlock()
 
 	// Double-check in case another goroutine fetched while we waited for write lock
-	item, exists = c.cache[key]
-	if exists && time.Now().Before(item.ExpiresAt) {
-		return item.UserInfo, nil
+	if c.item != nil && time.Now().Before(c.item.ExpiresAt) {
+		return c.item.UserInfo, nil
 	}
 
 	// Fetch new data
 	userInfo, ttl, err := fetchFunc()
 	if err != nil {
-		// Remove expired item on fetch failure
-		delete(c.cache, key)
+		// Clear expired item on fetch failure
+		c.item = nil
 		return nil, err
 	}
 
 	// Store in cache
-	c.cache[key] = &CacheItem{
+	c.item = &CacheItem{
 		UserInfo:  userInfo,
 		ExpiresAt: time.Now().Add(ttl),
 	}

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -31,6 +32,26 @@ type ErrorResponse struct {
 
 func (e *ErrorResponse) Message() string {
 	return fmt.Sprintf("message: %s, errorCode: %s", e.ErrorMessage, e.ErrorCode)
+}
+
+// UserInfoError represents errors from User Info endpoint failures.
+type UserInfoError struct {
+	Message string
+	Cause   error
+}
+
+func (e *UserInfoError) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("user info error: %s (caused by: %v)", e.Message, e.Cause)
+	}
+	return fmt.Sprintf("user info error: %s", e.Message)
+}
+
+func NewUserInfoError(message string, cause error) *UserInfoError {
+	return &UserInfoError{
+		Message: message,
+		Cause:   cause,
+	}
 }
 
 type pageToken struct {
@@ -177,4 +198,96 @@ type PermissionProfile struct {
 	CreatedDateTime       time.Time `json:"createdDateTime"`
 	LastModifiedDateTime  time.Time `json:"lastModifiedDateTime"`
 	ModifiedByUserName    string    `json:"modifiedByUserName"`
+}
+
+// UserInfoResponse represents the response from DocuSign's OAuth User Info endpoint.
+type UserInfoResponse struct {
+	Sub      string        `json:"sub"`
+	Name     string        `json:"name"`
+	Email    string        `json:"email"`
+	Accounts []AccountInfo `json:"accounts"`
+}
+
+// AccountInfo represents account information from the User Info response.
+type AccountInfo struct {
+	AccountId      string `json:"account_id"`
+	IsDefault      bool   `json:"is_default"`
+	AccountName    string `json:"account_name"`
+	BaseURI        string `json:"base_uri"`
+	OrganizationId string `json:"organization_id"`
+}
+
+// CacheItem holds cached User Info data with expiry time.
+type CacheItem struct {
+	UserInfo  *UserInfoResponse
+	ExpiresAt time.Time
+}
+
+// UserInfoCache provides thread-safe caching for User Info responses.
+type UserInfoCache struct {
+	cache map[string]*CacheItem
+	mutex sync.RWMutex
+}
+
+// NewUserInfoCache creates a new UserInfoCache instance.
+func NewUserInfoCache() *UserInfoCache {
+	cache := &UserInfoCache{
+		cache: make(map[string]*CacheItem),
+	}
+
+	// Start cleanup goroutine to remove expired entries
+	go cache.cleanup()
+
+	return cache
+}
+
+// Set stores User Info data in the cache with TTL.
+func (c *UserInfoCache) Set(key string, userInfo *UserInfoResponse, ttl time.Duration) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.cache[key] = &CacheItem{
+		UserInfo:  userInfo,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+}
+
+// Get retrieves User Info data from the cache if not expired.
+func (c *UserInfoCache) Get(key string) (*UserInfoResponse, bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	item, exists := c.cache[key]
+	if !exists {
+		return nil, false
+	}
+
+	if time.Now().After(item.ExpiresAt) {
+		// Item expired, clean it up
+		go func() {
+			c.mutex.Lock()
+			defer c.mutex.Unlock()
+			delete(c.cache, key)
+		}()
+		return nil, false
+	}
+
+	return item.UserInfo, true
+}
+
+// cleanup removes expired entries from the cache periodically.
+func (c *UserInfoCache) cleanup() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		c.mutex.Lock()
+		now := time.Now()
+		for key, item := range c.cache {
+			if now.After(item.ExpiresAt) {
+				delete(c.cache, key)
+			}
+		}
+		c.mutex.Unlock()
+	}
 }

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -33,26 +33,6 @@ func (e *ErrorResponse) Message() string {
 	return fmt.Sprintf("message: %s, errorCode: %s", e.ErrorMessage, e.ErrorCode)
 }
 
-// UserInfoError represents errors from User Info endpoint failures.
-type UserInfoError struct {
-	Message string
-	Cause   error
-}
-
-func (e *UserInfoError) Error() string {
-	if e.Cause != nil {
-		return fmt.Sprintf("user info error: %s (caused by: %v)", e.Message, e.Cause)
-	}
-	return fmt.Sprintf("user info error: %s", e.Message)
-}
-
-func NewUserInfoError(message string, cause error) *UserInfoError {
-	return &UserInfoError{
-		Message: message,
-		Cause:   cause,
-	}
-}
-
 type pageToken struct {
 	StartPosition int `json:"start_position"`
 }

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"sync"
 	"time"
 )
 
@@ -215,79 +214,4 @@ type AccountInfo struct {
 	AccountName    string `json:"account_name"`
 	BaseURI        string `json:"base_uri"`
 	OrganizationId string `json:"organization_id"`
-}
-
-// CacheItem holds cached User Info data with expiry time.
-type CacheItem struct {
-	UserInfo  *UserInfoResponse
-	ExpiresAt time.Time
-}
-
-// UserInfoCache provides thread-safe caching for User Info responses.
-type UserInfoCache struct {
-	cache map[string]*CacheItem
-	mutex sync.RWMutex
-}
-
-// NewUserInfoCache creates a new UserInfoCache instance.
-func NewUserInfoCache() *UserInfoCache {
-	cache := &UserInfoCache{
-		cache: make(map[string]*CacheItem),
-	}
-
-	// Start cleanup goroutine to remove expired entries
-	go cache.cleanup()
-
-	return cache
-}
-
-// Set stores User Info data in the cache with TTL.
-func (c *UserInfoCache) Set(key string, userInfo *UserInfoResponse, ttl time.Duration) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	c.cache[key] = &CacheItem{
-		UserInfo:  userInfo,
-		ExpiresAt: time.Now().Add(ttl),
-	}
-}
-
-// Get retrieves User Info data from the cache if not expired.
-func (c *UserInfoCache) Get(key string) (*UserInfoResponse, bool) {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
-	item, exists := c.cache[key]
-	if !exists {
-		return nil, false
-	}
-
-	if time.Now().After(item.ExpiresAt) {
-		// Item expired, clean it up
-		go func() {
-			c.mutex.Lock()
-			defer c.mutex.Unlock()
-			delete(c.cache, key)
-		}()
-		return nil, false
-	}
-
-	return item.UserInfo, true
-}
-
-// cleanup removes expired entries from the cache periodically.
-func (c *UserInfoCache) cleanup() {
-	ticker := time.NewTicker(5 * time.Minute)
-	defer ticker.Stop()
-
-	for range ticker.C {
-		c.mutex.Lock()
-		now := time.Now()
-		for key, item := range c.cache {
-			if now.After(item.ExpiresAt) {
-				delete(c.cache, key)
-			}
-		}
-		c.mutex.Unlock()
-	}
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -64,10 +64,10 @@ func (d *Connector) Validate(_ context.Context) (annotations.Annotations, error)
 	return nil, nil
 }
 
-func New(ctx context.Context, apiUrl, accountId, clientId, clientSecret, redirectURI, refreshToken string) (*Connector, error) {
+func New(ctx context.Context, isDemo bool, clientId, clientSecret, redirectURI, refreshToken string) (*Connector, error) {
 	l := ctxzap.Extract(ctx)
 
-	docusignClient, err := client.New(ctx, apiUrl, accountId, clientId, clientSecret, redirectURI, refreshToken)
+	docusignClient, err := client.New(ctx, isDemo, clientId, clientSecret, redirectURI, refreshToken)
 	if err != nil {
 		l.Error("error creating DocuSign client", zap.Error(err))
 		return nil, err

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -91,8 +91,9 @@ func New(ctx context.Context, isDemo bool, clientId, clientSecret, redirectURI, 
 	}, nil
 }
 
-func NewWithClient(client *client.Client) (*Connector, error) {
+func NewWithClient(client *client.Client, skipSigningGroups bool) (*Connector, error) {
 	return &Connector{
-		client: client,
+		client:            client,
+		skipSigningGroups: skipSigningGroups,
 	}, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -13,16 +13,23 @@ import (
 )
 
 type Connector struct {
-	client *client.Client
+	client            *client.Client
+	skipSigningGroups bool
 }
 
 func (d *Connector) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncer {
-	return []connectorbuilder.ResourceSyncer{
+	syncers := []connectorbuilder.ResourceSyncer{
 		newUserBuilder(d.client),
 		newGroupBuilder(d.client),
-		newSigningGroupBuilder(d.client),
 		newPermissionProfilesBuilder(d.client),
 	}
+
+	// Only include signing groups if not skipped
+	if !d.skipSigningGroups {
+		syncers = append(syncers, newSigningGroupBuilder(d.client))
+	}
+
+	return syncers
 }
 
 func (d *Connector) Asset(_ context.Context, _ *v2.AssetRef) (string, io.ReadCloser, error) {
@@ -30,9 +37,14 @@ func (d *Connector) Asset(_ context.Context, _ *v2.AssetRef) (string, io.ReadClo
 }
 
 func (d *Connector) Metadata(_ context.Context) (*v2.ConnectorMetadata, error) {
+	description := "Connector syncs data from Users, Permission Profiles, and Groups. It also allows the creation of users in DocuSign"
+	if !d.skipSigningGroups {
+		description = "Connector syncs data from Users, Permission Profiles, Groups, and Signing Groups. It also allows the creation of users in DocuSign"
+	}
+
 	return &v2.ConnectorMetadata{
 		DisplayName: "DocuSign",
-		Description: "Connector syncs data from Users, Permissions Profiles, Groups and Signing Groups. It also allows the creation users of DocuSign",
+		Description: description,
 		AccountCreationSchema: &v2.ConnectorAccountCreationSchema{
 			FieldMap: map[string]*v2.ConnectorAccountCreationSchema_Field{
 				"email": {
@@ -64,7 +76,7 @@ func (d *Connector) Validate(_ context.Context) (annotations.Annotations, error)
 	return nil, nil
 }
 
-func New(ctx context.Context, isDemo bool, clientId, clientSecret, redirectURI, refreshToken string) (*Connector, error) {
+func New(ctx context.Context, isDemo bool, clientId, clientSecret, redirectURI, refreshToken string, skipSigningGroups bool) (*Connector, error) {
 	l := ctxzap.Extract(ctx)
 
 	docusignClient, err := client.New(ctx, isDemo, clientId, clientSecret, redirectURI, refreshToken)
@@ -74,7 +86,8 @@ func New(ctx context.Context, isDemo bool, clientId, clientSecret, redirectURI, 
 	}
 
 	return &Connector{
-		client: docusignClient,
+		client:            docusignClient,
+		skipSigningGroups: skipSigningGroups,
 	}, nil
 }
 

--- a/pkg/connector/integration_test.go
+++ b/pkg/connector/integration_test.go
@@ -23,17 +23,17 @@ var (
 func initClient(t *testing.T) *client.Client {
 	ctx := context.Background()
 
-	apiURL, apiOK := os.LookupEnv("DOCUSIGN_API_URL")
-	accountID, accOK := os.LookupEnv("DOCUSIGN_ACCOUNT_ID")
+	isDemoStr, demoOK := os.LookupEnv("DOCUSIGN_IS_DEMO")
 	clientID, cliOK := os.LookupEnv("DOCUSIGN_CLIENT_ID")
 	clientSecret, secOK := os.LookupEnv("DOCUSIGN_CLIENT_SECRET")
 	redirectURI, redirOK := os.LookupEnv("DOCUSIGN_REDIRECT_URI")
 
-	if !apiOK || !accOK || !cliOK || !secOK || !redirOK {
+	if !demoOK || !cliOK || !secOK || !redirOK {
 		t.Skip("One or more required environment variables are missing. Skipping integration test.")
 	}
 
-	client, err := client.New(ctx, apiURL, accountID, clientID, clientSecret, redirectURI, "")
+	isDemo := isDemoStr == "true"
+	client, err := client.New(ctx, isDemo, clientID, clientSecret, redirectURI, "")
 	if err != nil {
 		t.Fatalf("Failed to create DocuSign client: %v", err)
 	}

--- a/test/testutils.go
+++ b/test/testutils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -120,9 +121,76 @@ func ReadFile(fileName string) string {
 	return string(data)
 }
 
+// MultiEndpointMockTransport handles multiple endpoints with different responses.
+type MultiEndpointMockTransport struct {
+	Responses map[string]*http.Response
+	Errors    map[string]error
+}
+
+func (m *MultiEndpointMockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqURL := req.URL.String()
+
+	// Check for User Info endpoint first
+	if strings.Contains(reqURL, "account-d.docusign.com/oauth/userinfo") || strings.Contains(reqURL, "account.docusign.com/oauth/userinfo") {
+		return createUserInfoResponse(), nil
+	}
+
+	// For other endpoints, match by path only since baseURL in test varies
+	requestPath := req.URL.Path
+	for responseURL, resp := range m.Responses {
+		parsedURL, err := url.Parse(responseURL)
+		if err != nil {
+			continue
+		}
+		if parsedURL.Path == requestPath {
+			return resp, m.Errors[responseURL]
+		}
+	}
+
+	// Default fallback with proper headers
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	return &http.Response{
+		StatusCode: http.StatusNotFound,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(`{"error": "not found"}`)),
+	}, nil
+}
+
+func createUserInfoResponse() *http.Response {
+	userInfoJSON := `{
+		"sub": "test-user-id",
+		"name": "Test User",
+		"email": "test@example.com",
+		"accounts": [
+			{
+				"account_id": "` + MockAccountID + `",
+				"is_default": true,
+				"account_name": "Test Account",
+				"base_uri": "` + MockBaseURL + `",
+				"organization_id": "test-org-id"
+			}
+		]
+	}`
+
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(userInfoJSON)),
+	}
+}
+
 // NewTestClient prepares a Client pointing to a mock endpoint.
 func NewTestClient(response *http.Response, err error) *client.Client {
-	mockTransport := &MockRoundTripper{Response: response, Err: err}
+	mockTransport := &MultiEndpointMockTransport{
+		Responses: map[string]*http.Response{},
+		Errors:    map[string]error{},
+	}
+
 	httpClient := &http.Client{Transport: mockTransport}
 	baseHttpClient := uhttp.NewBaseHttpClient(httpClient)
 	staticTokenSource := oauth2.StaticTokenSource(&oauth2.Token{
@@ -131,8 +199,7 @@ func NewTestClient(response *http.Response, err error) *client.Client {
 	})
 	return client.NewClient(
 		context.Background(),
-		MockBaseURL,
-		MockAccountID,
+		true, // isDemo
 		staticTokenSource,
 		baseHttpClient,
 	)


### PR DESCRIPTION
Based on the error we are seeing now I made the change to get the api URL from base info as per
```
{ "error": "error: listing resources failed: rpc error: code = Unknown desc = 400 Bad Request\nrpc error: code = Unknown desc = Request failed with status 400: message: The specified Integrator Key was not found or is disabled. Invalid account specified for user., errorCode: PARTNER_AUTHENTICATION_FAILED\nunexpected status code: 400" }
```


https://www.docusign.com/blog/developers/dsdev-from-the-trenches-may-2020

Replaces hardcoded API URL and account ID with dynamic resolution via DocuSign's OAuth User Info endpoint. This fixes production authentication failures caused by using incorrect base URIs for different DocuSign datacenters.

Key changes:
- Add User Info endpoint integration with caching and retry logic
- Replace api-url and account-id config with demo boolean flag
- Update all client methods to use dynamic base URI resolution
- Add comprehensive error handling for User Info failures
- Update tests with multi-endpoint mock transport
- Support for all DocuSign datacenters (NA1, NA2, NA3, EU, etc.)

https://developers.docusign.com/platform/auth/reference/user-info/