### PR TITLE
Make signing groups opt in instead of opt out

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,6 @@ jobs:
       - name: Validate capabilities
         run: |
           ./baton-docusign \
-            --account-id "$ACCOUNTID" \
             --clientId "$CLIENTID" \
             --clientSecret "$CLIENTSECRET" \
             --redirect-uri "$REDIRECTURI" \
@@ -73,7 +72,6 @@ jobs:
       - name: Run basic sync test
         run: |
           ./baton-docusign \
-            --account-id "$ACCOUNTID" \
             --clientId "$CLIENTID" \
             --clientSecret "$CLIENTSECRET" \
             --redirect-uri "$REDIRECTURI"\

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Flags:
       --redirect-uri string                              required: Redirect URI registered in your DocuSign integration ($BATON_REDIRECT_URI)
       --refresh-token string                             required: Refresh token. ($BATON_REFRESH_TOKEN)
       --skip-full-sync                                   This must be set to skip a full sync ($BATON_SKIP_FULL_SYNC)
-      --skip-signing-groups                              Set to true to skip syncing signing groups (for customers without signing groups feature enabled) ($BATON_SKIP_SIGNING_GROUPS)
+      --include-signing-groups                           Set to true to include syncing signing groups (for customers with signing groups feature enabled) ($BATON_INCLUDE_SIGNING_GROUPS)
       --ticketing                                        This must be set to enable ticketing support ($BATON_TICKETING)
   -v, --version                                          version for baton-docusign
 

--- a/cmd/baton-docusign/config.go
+++ b/cmd/baton-docusign/config.go
@@ -35,9 +35,9 @@ var (
 		field.WithRequired(true),
 	)
 
-	skipSigningGroupsField = field.BoolField(
-		"skip-signing-groups",
-		field.WithDescription("Set to true to skip syncing signing groups (for customers without signing groups feature enabled)"),
+	includeSigningGroupsField = field.BoolField(
+		"include-signing-groups",
+		field.WithDescription("Set to true to include syncing signing groups (for customers with signing groups feature enabled)"),
 		field.WithDefaultValue(false),
 	)
 
@@ -47,7 +47,7 @@ var (
 		clientSecretField,
 		redirectURIField,
 		refreshTokenField,
-		skipSigningGroupsField,
+		includeSigningGroupsField,
 	}
 
 	FieldRelationships = []field.SchemaFieldRelationship{}

--- a/cmd/baton-docusign/main.go
+++ b/cmd/baton-docusign/main.go
@@ -53,9 +53,9 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 	docusignClientSecret := v.GetString(clientSecretField.FieldName)
 	docusignRedirectURI := v.GetString(redirectURIField.FieldName)
 	docusignRefreshToken := v.GetString(refreshTokenField.FieldName)
-	skipSigningGroups := v.GetBool(skipSigningGroupsField.FieldName)
+	includeSigningGroups := v.GetBool(includeSigningGroupsField.FieldName)
 
-	cb, err := connectorSchema.New(ctx, isDemo, docusignClientId, docusignClientSecret, docusignRedirectURI, docusignRefreshToken, skipSigningGroups)
+	cb, err := connectorSchema.New(ctx, isDemo, docusignClientId, docusignClientSecret, docusignRedirectURI, docusignRefreshToken, includeSigningGroups)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -13,8 +13,8 @@ import (
 )
 
 type Connector struct {
-	client            *client.Client
-	skipSigningGroups bool
+	client               *client.Client
+	includeSigningGroups bool
 }
 
 func (d *Connector) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncer {
@@ -24,8 +24,8 @@ func (d *Connector) ResourceSyncers(_ context.Context) []connectorbuilder.Resour
 		newPermissionProfilesBuilder(d.client),
 	}
 
-	// Only include signing groups if not skipped
-	if !d.skipSigningGroups {
+	// Only include signing groups if opted in
+	if d.includeSigningGroups {
 		syncers = append(syncers, newSigningGroupBuilder(d.client))
 	}
 
@@ -38,7 +38,7 @@ func (d *Connector) Asset(_ context.Context, _ *v2.AssetRef) (string, io.ReadClo
 
 func (d *Connector) Metadata(_ context.Context) (*v2.ConnectorMetadata, error) {
 	description := "Connector syncs data from Users, Permission Profiles, and Groups. It also allows the creation of users in DocuSign"
-	if !d.skipSigningGroups {
+	if d.includeSigningGroups {
 		description = "Connector syncs data from Users, Permission Profiles, Groups, and Signing Groups. It also allows the creation of users in DocuSign"
 	}
 
@@ -76,7 +76,7 @@ func (d *Connector) Validate(_ context.Context) (annotations.Annotations, error)
 	return nil, nil
 }
 
-func New(ctx context.Context, isDemo bool, clientId, clientSecret, redirectURI, refreshToken string, skipSigningGroups bool) (*Connector, error) {
+func New(ctx context.Context, isDemo bool, clientId, clientSecret, redirectURI, refreshToken string, includeSigningGroups bool) (*Connector, error) {
 	l := ctxzap.Extract(ctx)
 
 	docusignClient, err := client.New(ctx, isDemo, clientId, clientSecret, redirectURI, refreshToken)
@@ -86,14 +86,14 @@ func New(ctx context.Context, isDemo bool, clientId, clientSecret, redirectURI, 
 	}
 
 	return &Connector{
-		client:            docusignClient,
-		skipSigningGroups: skipSigningGroups,
+		client:               docusignClient,
+		includeSigningGroups: includeSigningGroups,
 	}, nil
 }
 
-func NewWithClient(client *client.Client, skipSigningGroups bool) (*Connector, error) {
+func NewWithClient(client *client.Client, includeSigningGroups bool) (*Connector, error) {
 	return &Connector{
-		client:            client,
-		skipSigningGroups: skipSigningGroups,
+		client:               client,
+		includeSigningGroups: includeSigningGroups,
 	}, nil
 }


### PR DESCRIPTION
opt out is bad for many reasons, syncs fail unless you opt out if you don't have the option, when you do enable it and you have an in progress sync erroring it starts erroring on unknow resource. This requires support dashboard to fix. It also fails the sync because it is a bad sync if you disable it once you had it.
