### PR TITLE
docs: update style to match docs site

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -73,7 +73,7 @@ A user with access to the **Docusign Admin console** must perform this task.
   </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Docusign connector
 
@@ -149,7 +149,7 @@ To complete this task, you'll need the **Connector Administrator** or **Super Ad
   </Step>
 </Steps>
 
-**That's it!** Your Docusign connector is now pulling access data into C1.
+**Done.** Your Docusign connector is now pulling access data into C1.
 
 </Tab>
 <Tab title="Self-hosted">
@@ -286,7 +286,7 @@ spec:
   </Step>
 </Steps>
 
-**That's it!** Your Docusign connector is now pulling access data into C1.
+**Done.** Your Docusign connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

Syncs `docs/connector.mdx` style with the canonical docs site to prevent regressions on next release.

Changes applied where present:
- Docker image URL: `ghcr.io/conductorone/` → `public.ecr.aws/conductorone/`
- Phrasing: `**That's it!**` → `**Done.**`
- Icon color: `#65DE23` → `#c937ae`
- Branding: `ConductorOne` → `C1` in product references
- GitHub URLs: lowercased org name

These match the [docs site](https://docs.conductorone.com) and were identified via an automated sync audit.